### PR TITLE
#25 店舗詳細ページからブラウザバックするとJSONキャッシュが表示される不具合修正

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -67,4 +67,14 @@ class Kernel extends HttpKernel
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
     ];
+
+    /**
+     * JSONでの検索後にブラウザバックするとJSONが表示される問題を解消するためのミドルウェア
+     * 全体適用をしないためにここで登録
+     *
+     * @var array
+     */
+    protected $routeMiddleware = [
+        'no-cache' => \App\Http\Middleware\NoCacheMiddleware::class,
+    ];
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,7 +28,9 @@ Route::group(['middleware' => ['auth:sanctum']], function () {
     });
 });
 
-Route::get('/shop/search', SearchShopByKeywordController::class)->name('api.shop.search.keyword');
+Route::middleware(['cache.headers:no_store,;max-age=0',])->group(function () {
+    Route::get('/shop/search', SearchShopByKeywordController::class)->name('api.shop.search.keyword');
+});
 
 Route::post('test/token', function (Request $request) {
     $credentials = $request->validate([


### PR DESCRIPTION
## 背景
- キーワード検索で店舗一覧に画面遷移後、ブラウザバックすると検索結果JSONが表示されてしまうため。
## 対応内容
- キャッシュを保持しないようにミドルウェアを通るように変更。
- 上記ミドルウェアを使用するのは検索ルートのみとする。
## テスト内容
- [x] キーワード検索で画面遷移後、ブラウザバックをしても検索結果JSONが画面に表示されないこと
